### PR TITLE
fix for undefined array key error

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -69,7 +69,7 @@ class ApiClient
                 $statusCode = $response->getStatusCode();
                 $body = $response->getBody()->getContents();
                 $json = json_decode($body, true);
-                if ($json['msg']) {
+                if (isset($json['msg']) && $json['msg']) {
                     throw new UnipaymentSDKException($json['msg'], $statusCode);
                 }
             }


### PR DESCRIPTION
Because the try catch is not catching the "undefined array key" and it's throwing error - tested in Laravel 10 project